### PR TITLE
Redo voice line parsing, add elapsed time, fix progress indicator

### DIFF
--- a/StarfieldVT.Core/DialogueTreeBuilder.cs
+++ b/StarfieldVT.Core/DialogueTreeBuilder.cs
@@ -24,6 +24,7 @@ namespace StarfieldVT.Core
 
         public List<Models.Master> BuildTree(IProgress<EsmLoadingProgress> progress)
         {
+            var startTime = DateTime.Now;
             using var env = GameEnvironment.Typical.Starfield(StarfieldRelease.Starfield);
             var linkCache = env.LinkCache;
             var tree = env.LoadOrder.PriorityOrder.Where(esm => esm is { Enabled: true, ExistsOnDisk: true }).Select(
@@ -85,165 +86,10 @@ namespace StarfieldVT.Core
 
                     return null;
                 }).Where(master => master != null).ToList();
-            // var tree = env.LoadOrder.ListedOrder.Where(esm => esm is { Enabled: true, ExistsOnDisk: true }).Select(esm =>
-            // {
-            //     Log.Information($"Loading plugin {esm.FileName}");
-            //     var tempDict = new ConcurrentDictionary<string, List<VoiceLine>>();
-            //     var questCount = 1;
-            //
-            //     esm.Mod?.Quests.ForEach(quest =>
-            //     {
-            //         Log.Debug($"Parsing quest {quest.EditorID} in {esm.FileName}");
-            //
-            //         progress.Report(new EsmLoadingProgress()
-            //         {
-            //             esmName = quest.EditorID,
-            //             num = questCount
-            //         });
-            //
-            //         quest.DialogTopics.ForEach(dt =>
-            //         {
-            //             Log.Debug($"Parsing dialogue {dt.Name} in {esm.FileName}");
-            //             // lastly, lets fall back on the conditions in the quest if there's no speakers
-            //             var allVoiceTypesInQuest = GetQuestConditionalVoiceTypes(quest, linkCache);
-            //             dt.Responses.ForEach(resp =>
-            //             {
-            //                 Log.Debug($"Parsing response {dt.FormKey} with {resp.Responses.Count} responses in {esm.FileName}");
-            //                 resp.Responses.Where(innerResp => innerResp.TROTs.Count <= 0).ForEach(innerResp =>
-            //                 {
-            //                     innerResp.Text.TryLookup(Language.English, out var innerRespText);
-            //                     // get the group editor id if there's no speaker
-            //                     // string? speaker = null;
-            //                     // if (resp.Speaker.IsNull)
-            //                     // {
-            //                     //     speaker = resp.DialogGroup.TryResolve(linkCache)?.EditorID;
-            //                     // }
-            //                     // else
-            //                     // {
-            //                     //     speaker = resp.Speaker.TryResolve(linkCache)?.EditorID;
-            //                     // }
-            //                     
-            //                     // go crazy trying to find a voice type lol
-            //                     var speakers = new List<string>();
-            //                     var mainSpeaker = resp.Speaker.TryResolve(linkCache)?.EditorID;
-            //                     if (mainSpeaker != null)
-            //                     {
-            //                         speakers.Add(mainSpeaker);
-            //                     }
-            //                     
-            //                     var groupSpeaker = resp.DialogGroup.TryResolve(linkCache)?.EditorID;
-            //                     if (groupSpeaker != null)
-            //                     {
-            //                         speakers.Add(groupSpeaker);
-            //                     }
-            //
-            //                     if (!string.IsNullOrEmpty(innerRespText) && speaker != null)
-            //                     {
-            //                         if (resp.DialogGroup.IsNull)
-            //                         {
-            //                             var voiceType = resp.Speaker?.TryResolve(linkCache)?.Voice.TryResolve(linkCache).EditorID;
-            //
-            //                             if (voiceType != null)
-            //                             {
-            //                                 var wemPath = BuildWemPath(esm.FileName, voiceType, innerResp.WEMFile.ToString("x8"));
-            //
-            //                                 List<VoiceLine> voiceLineList = [new VoiceLine(wemPath, innerRespText, esm.FileName, voiceType)];
-            //                                 tempDict.AddOrUpdate(voiceType, voiceLineList, (_, lines) => lines.Append(new VoiceLine(wemPath, innerRespText, esm.FileName, voiceType)).ToList());
-            //                             }
-            //                         }
-            //                         else
-            //                         {
-            //                             var voiceTypes = resp.DialogGroup.TryResolve(linkCache)?.Conditions
-            //                                 .Where(condition => condition.Data is GetIsVoiceTypeConditionData)
-            //                                 .Select(condition => ((GetIsVoiceTypeConditionData)condition.Data).FirstParameter.Link.TryResolve(linkCache)?.EditorID).OfType<string>();
-            //                             var aliasVoiceTypes = resp.DialogGroup.TryResolve(linkCache)?.Conditions
-            //                                 .Where(condition => condition.Data is GetIsAliasRefConditionData)
-            //                                 .Where(condition =>
-            //                                     ((GetIsAliasRefConditionData)condition.Data).SecondParameter ==
-            //                                     1) // is true
-            //                                 .Select(cond =>
-            //                                 {
-            //                                     var aliasNum = ((GetIsAliasRefConditionData)cond.Data).FirstParameter;
-            //                                     if (quest.Aliases != null)
-            //                                     {
-            //                                         quest.Aliases.OfType<QuestReferenceAlias>()
-            //                                             .Where(alias => alias.)
-            //                                             .First(alias => alias.ID == aliasNum);
-            //                                     }
-            //                                 });
-            //                             voiceTypes?.ForEach(vt =>
-            //                             {
-            //                                 var wemPath = BuildWemPath(esm.FileName, vt, innerResp.WEMFile.ToString("x8"));
-            //                                 List<VoiceLine> voiceLines = [new VoiceLine(wemPath, innerRespText, esm.FileName, vt)];
-            //                                 tempDict.AddOrUpdate(vt, voiceLines, (_, lines) => lines.Append(new VoiceLine(wemPath, innerRespText, esm.FileName, vt)).ToList());
-            //                             });
-            //                         }
-            //                     }
-            //                     else
-            //                     {
-            //                         allVoiceTypesInQuest?.ForEach(voiceType =>
-            //                         {
-            //                             var wemPath = BuildWemPath(esm.FileName, voiceType,
-            //                                 innerResp.WEMFile.ToString("x8"));
-            //
-            //                             List<VoiceLine> voiceLineList =
-            //                                 [new VoiceLine(wemPath, innerRespText, esm.FileName, voiceType)];
-            //                             tempDict.AddOrUpdate(voiceType, voiceLineList,
-            //                                 (_, lines) =>
-            //                                     lines.Append(new VoiceLine(wemPath, innerRespText, esm.FileName,
-            //                                         voiceType)).ToList());
-            //                         });
-            //                     }
-            //                 });
-            //
-            //                 resp.Responses.Where(innerResp => innerResp.TROTs.Count > 0).ForEach(innerResp =>
-            //                 {
-            //                     innerResp.Text.TryLookup(Language.English, out var dialogueText);
-            //                     Log.Debug($"Parsing inner response {dialogueText}");
-            //                     // needs to support multiple unknown voice types
-            //                     var editorId = innerResp.TROTs
-            //                         .Select(trot => trot.UnknownVoiceType.TryResolve(linkCache)?.EditorID).OfType<string>();
-            //
-            //                     editorId.ForEach(voiceType =>
-            //                     {
-            //                         if (dialogueText != null)
-            //                         {
-            //                             var wemPath = BuildWemPath(esm.FileName, voiceType, innerResp.WEMFile.ToString("x8"));
-            //                             List<VoiceLine> voiceLineList = [new(wemPath, dialogueText, esm.FileName, voiceType)];
-            //                             tempDict.AddOrUpdate(voiceType, voiceLineList, (_, lines) => lines.Append(new VoiceLine(wemPath, dialogueText, esm.FileName, voiceType)).ToList());
-            //                         }
-            //                     });
-            //                 });
-            //
-            //             });
-            //         });
-            //
-            //         questCount++;
-            //     });
-            //
-            //     var voiceTypes = tempDict.Select(voiceType =>
-            //     {
-            //         var editorId = voiceType.Key;
-            //         var lines = voiceType.Value;
-            //         return new VoiceType()
-            //         {
-            //             EditorId = editorId,
-            //             VoiceLines = lines
-            //         };
-            //
-            //     }).OrderBy(voiceType => voiceType.EditorId).ToList();
-            //
-            //     if (voiceTypes.Count > 0)
-            //     {
-            //         return new Master(esm.FileName, voiceTypes);
-            //     }
-            //
-            //     return null;
-            // }).Where(master => master != null).ToList();
 
             SaveCache(tree);
-            Log.Information("Found {0} lines", lineCount);
-
+            var elapsedTime = DateTime.Now - startTime;
+            Log.Information("Found {0} lines in {1} seconds", lineCount, elapsedTime.TotalSeconds);
             return tree;
         }
 

--- a/StarfieldVT.Core/DialogueTreeBuilder.cs
+++ b/StarfieldVT.Core/DialogueTreeBuilder.cs
@@ -27,7 +27,7 @@ namespace StarfieldVT.Core
             var startTime = DateTime.Now;
             using var env = GameEnvironment.Typical.Starfield(StarfieldRelease.Starfield);
             var linkCache = env.LinkCache;
-            var tree = env.LoadOrder.PriorityOrder.Where(esm => esm is { Enabled: true, ExistsOnDisk: true }).Select(
+            var tree = env.LoadOrder.ListedOrder.Where(esm => esm is { Enabled: true, ExistsOnDisk: true }).Select(
                 esm =>
                 {
                     Log.Information($"Loading plugin {esm.FileName}");
@@ -41,7 +41,7 @@ namespace StarfieldVT.Core
 
                         progress.Report(new EsmLoadingProgress()
                         {
-                            esmName = quest.EditorID,
+                            esmName = esm.FileName,
                             num = questCount
                         });
 
@@ -90,6 +90,7 @@ namespace StarfieldVT.Core
             SaveCache(tree);
             var elapsedTime = DateTime.Now - startTime;
             Log.Information("Found {0} lines in {1} seconds", lineCount, elapsedTime.TotalSeconds);
+
             return tree;
         }
 

--- a/StarfieldVT.Core/DialogueTreeBuilder.cs
+++ b/StarfieldVT.Core/DialogueTreeBuilder.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Concurrent;
-
 using Mutagen.Bethesda;
 using Mutagen.Bethesda.Environments;
 using Mutagen.Bethesda.Plugins.Cache;
+using Mutagen.Bethesda.Plugins.Order;
 using Mutagen.Bethesda.Starfield;
 using Mutagen.Bethesda.Strings;
 
@@ -19,141 +19,236 @@ namespace StarfieldVT.Core
     public class DialogueTreeBuilder
     {
         private readonly VoiceLineTreeCacheManager _voiceLineTreeCacheManager = new VoiceLineTreeCacheManager();
+        private readonly VoiceArchiveManager _voiceArchiveManager = new VoiceArchiveManager();
+        private int lineCount = 0;
+
         public List<Models.Master> BuildTree(IProgress<EsmLoadingProgress> progress)
         {
             using var env = GameEnvironment.Typical.Starfield(StarfieldRelease.Starfield);
             var linkCache = env.LinkCache;
-            var tree = env.LoadOrder.ListedOrder.Where(esm => esm is { Enabled: true, ExistsOnDisk: true }).Select(esm =>
-            {
-                Log.Information($"Loading plugin {esm.FileName}");
-                var tempDict = new ConcurrentDictionary<string, List<VoiceLine>>();
-                var questCount = 1;
-
-                esm.Mod?.Quests.ForEach(quest =>
+            var tree = env.LoadOrder.PriorityOrder.Where(esm => esm is { Enabled: true, ExistsOnDisk: true }).Select(
+                esm =>
                 {
-                    Log.Debug($"Parsing quest {quest.EditorID} in {esm.FileName}");
+                    Log.Information($"Loading plugin {esm.FileName}");
+                    var tempDict = new ConcurrentDictionary<string, List<VoiceLine>>();
+                    var questCount = 1;
+                    var wemMap = _voiceArchiveManager.BuildWemMap(esm.FileName);
 
-                    progress.Report(new EsmLoadingProgress()
+                    esm.Mod?.Quests.ForEach(quest =>
                     {
-                        esmName = quest.EditorID,
-                        num = questCount
-                    });
+                        Log.Debug($"Parsing quest {quest.EditorID} in {esm.FileName}");
 
-                    quest.DialogTopics.ForEach(dt =>
-                    {
-                        Log.Debug($"Parsing dialogue {dt.Name} in {esm.FileName}");
-                        // lastly, lets fall back on the conditions in the quest if there's no speakers
-                        var allVoiceTypesInQuest = GetQuestConditionalVoiceTypes(quest, linkCache);
-                        dt.Responses.ForEach(resp =>
+                        progress.Report(new EsmLoadingProgress()
                         {
-                            Log.Debug($"Parsing response {dt.FormKey} with {resp.Responses.Count} responses in {esm.FileName}");
-                            resp.Responses.Where(innerResp => innerResp.TROTs.Count <= 0).ForEach(innerResp =>
-                            {
-                                innerResp.Text.TryLookup(Language.English, out var innerRespText);
-                                // get the group editor id if there's no speaker
-                                string? speaker = null;
-                                if (resp.Speaker.IsNull)
-                                {
-                                    speaker = resp.DialogGroup.TryResolve(linkCache)?.EditorID;
-                                }
-                                else
-                                {
-                                    speaker = resp.Speaker.TryResolve(linkCache)?.EditorID;
-                                }
-
-                                if (!string.IsNullOrEmpty(innerRespText) && speaker != null)
-                                {
-                                    if (resp.DialogGroup.IsNull)
-                                    {
-                                        var voiceType = resp.Speaker?.TryResolve(linkCache)?.Voice.TryResolve(linkCache).EditorID;
-
-                                        if (voiceType != null)
-                                        {
-                                            var wemPath = BuildWemPath(esm.FileName, voiceType, innerResp.WEMFile.ToString("x8"));
-
-                                            List<VoiceLine> voiceLineList = [new VoiceLine(wemPath, innerRespText, esm.FileName, voiceType)];
-                                            tempDict.AddOrUpdate(voiceType, voiceLineList, (_, lines) => lines.Append(new VoiceLine(wemPath, innerRespText, esm.FileName, voiceType)).ToList());
-                                        }
-                                    }
-                                    else
-                                    {
-                                        // get the group and its voice type conditions
-                                        var voiceTypes = resp.DialogGroup.TryResolve(linkCache)?.Conditions
-                                            .Where(condition => condition.Data is GetIsVoiceTypeConditionData)
-                                            .Select(condition => ((GetIsVoiceTypeConditionData)condition.Data).FirstParameter.Link.TryResolve(linkCache)?.EditorID).OfType<string>();
-
-                                        voiceTypes?.ForEach(vt =>
-                                        {
-                                            var wemPath = BuildWemPath(esm.FileName, vt, innerResp.WEMFile.ToString("x8"));
-                                            List<VoiceLine> voiceLines = [new VoiceLine(wemPath, innerRespText, esm.FileName, vt)];
-                                            tempDict.AddOrUpdate(vt, voiceLines, (_, lines) => lines.Append(new VoiceLine(wemPath, innerRespText, esm.FileName, vt)).ToList());
-                                        });
-                                    }
-                                }
-                                else
-                                {
-                                    allVoiceTypesInQuest?.ForEach(voiceType =>
-                                    {
-                                        var wemPath = BuildWemPath(esm.FileName, voiceType,
-                                            innerResp.WEMFile.ToString("x8"));
-
-                                        List<VoiceLine> voiceLineList =
-                                            [new VoiceLine(wemPath, innerRespText, esm.FileName, voiceType)];
-                                        tempDict.AddOrUpdate(voiceType, voiceLineList,
-                                            (_, lines) =>
-                                                lines.Append(new VoiceLine(wemPath, innerRespText, esm.FileName,
-                                                    voiceType)).ToList());
-                                    });
-                                }
-                            });
-
-                            resp.Responses.Where(innerResp => innerResp.TROTs.Count > 0).ForEach(innerResp =>
-                            {
-                                innerResp.Text.TryLookup(Language.English, out var dialogueText);
-                                Log.Debug($"Parsing inner response {dialogueText}");
-                                var editorId = innerResp.TROTs
-                                    .Select(trot => trot.UnknownVoiceType.TryResolve(linkCache)?.EditorID).First();
-
-                                if (editorId != null && dialogueText != null)
-                                {
-                                    var wemPath = BuildWemPath(esm.FileName, editorId, innerResp.WEMFile.ToString("x8"));
-                                    List<VoiceLine> voiceLineList = [new VoiceLine(wemPath, dialogueText, esm.FileName, editorId)];
-                                    tempDict.AddOrUpdate(editorId, voiceLineList, (_, lines) => lines.Append(new VoiceLine(wemPath, dialogueText, esm.FileName, editorId)).ToList());
-                                }
-                            });
-
+                            esmName = quest.EditorID,
+                            num = questCount
                         });
+
+                        quest.DialogTopics.ForEach(dt =>
+                        {
+                            Log.Debug($"Parsing dialogue {dt.Name} in {esm.FileName}");
+                            // lastly, lets fall back on the conditions in the quest if there's no speakers
+                            var allVoiceTypesInQuest = GetQuestConditionalVoiceTypes(quest, linkCache);
+                            dt.Responses.ForEach(resp =>
+                            {
+                                Log.Debug(
+                                    $"Parsing response {dt.FormKey} with {resp.Responses.Count} responses in {esm.FileName}");
+                                resp.Responses.Where(innerResp => innerResp.TROTs.Count <= 0).ForEach(innerResp =>
+                                {
+                                    ProcessResponse(innerResp, esm, tempDict, wemMap);
+                                });
+                                resp.Responses.Where(innerResp => innerResp.TROTs.Count > 0).ForEach(innerResp =>
+                                {
+                                    ProcessResponse(innerResp, esm, tempDict, wemMap);
+                                });
+                            });
+                        });
+                        questCount++;
                     });
 
-                    questCount++;
-                });
-
-                var voiceTypes = tempDict.Select(voiceType =>
-                {
-                    var editorId = voiceType.Key;
-                    var lines = voiceType.Value;
-                    return new VoiceType()
+                    var voiceTypes = tempDict.Select(voiceType =>
                     {
-                        EditorId = editorId,
-                        VoiceLines = lines
-                    };
+                        var editorId = voiceType.Key;
+                        var lines = voiceType.Value;
+                        return new VoiceType()
+                        {
+                            EditorId = editorId,
+                            VoiceLines = lines
+                        };
 
-                }).OrderBy(voiceType => voiceType.EditorId).ToList();
+                    }).OrderBy(voiceType => voiceType.EditorId).ToList();
 
-                if (voiceTypes.Count > 0)
-                {
-                    return new Master(esm.FileName, voiceTypes);
-                }
+                    if (voiceTypes.Count > 0)
+                    {
+                        return new Master(esm.FileName, voiceTypes);
+                    }
 
-                return null;
-            }).Where(master => master != null).ToList();
+                    return null;
+                }).Where(master => master != null).ToList();
+            // var tree = env.LoadOrder.ListedOrder.Where(esm => esm is { Enabled: true, ExistsOnDisk: true }).Select(esm =>
+            // {
+            //     Log.Information($"Loading plugin {esm.FileName}");
+            //     var tempDict = new ConcurrentDictionary<string, List<VoiceLine>>();
+            //     var questCount = 1;
+            //
+            //     esm.Mod?.Quests.ForEach(quest =>
+            //     {
+            //         Log.Debug($"Parsing quest {quest.EditorID} in {esm.FileName}");
+            //
+            //         progress.Report(new EsmLoadingProgress()
+            //         {
+            //             esmName = quest.EditorID,
+            //             num = questCount
+            //         });
+            //
+            //         quest.DialogTopics.ForEach(dt =>
+            //         {
+            //             Log.Debug($"Parsing dialogue {dt.Name} in {esm.FileName}");
+            //             // lastly, lets fall back on the conditions in the quest if there's no speakers
+            //             var allVoiceTypesInQuest = GetQuestConditionalVoiceTypes(quest, linkCache);
+            //             dt.Responses.ForEach(resp =>
+            //             {
+            //                 Log.Debug($"Parsing response {dt.FormKey} with {resp.Responses.Count} responses in {esm.FileName}");
+            //                 resp.Responses.Where(innerResp => innerResp.TROTs.Count <= 0).ForEach(innerResp =>
+            //                 {
+            //                     innerResp.Text.TryLookup(Language.English, out var innerRespText);
+            //                     // get the group editor id if there's no speaker
+            //                     // string? speaker = null;
+            //                     // if (resp.Speaker.IsNull)
+            //                     // {
+            //                     //     speaker = resp.DialogGroup.TryResolve(linkCache)?.EditorID;
+            //                     // }
+            //                     // else
+            //                     // {
+            //                     //     speaker = resp.Speaker.TryResolve(linkCache)?.EditorID;
+            //                     // }
+            //                     
+            //                     // go crazy trying to find a voice type lol
+            //                     var speakers = new List<string>();
+            //                     var mainSpeaker = resp.Speaker.TryResolve(linkCache)?.EditorID;
+            //                     if (mainSpeaker != null)
+            //                     {
+            //                         speakers.Add(mainSpeaker);
+            //                     }
+            //                     
+            //                     var groupSpeaker = resp.DialogGroup.TryResolve(linkCache)?.EditorID;
+            //                     if (groupSpeaker != null)
+            //                     {
+            //                         speakers.Add(groupSpeaker);
+            //                     }
+            //
+            //                     if (!string.IsNullOrEmpty(innerRespText) && speaker != null)
+            //                     {
+            //                         if (resp.DialogGroup.IsNull)
+            //                         {
+            //                             var voiceType = resp.Speaker?.TryResolve(linkCache)?.Voice.TryResolve(linkCache).EditorID;
+            //
+            //                             if (voiceType != null)
+            //                             {
+            //                                 var wemPath = BuildWemPath(esm.FileName, voiceType, innerResp.WEMFile.ToString("x8"));
+            //
+            //                                 List<VoiceLine> voiceLineList = [new VoiceLine(wemPath, innerRespText, esm.FileName, voiceType)];
+            //                                 tempDict.AddOrUpdate(voiceType, voiceLineList, (_, lines) => lines.Append(new VoiceLine(wemPath, innerRespText, esm.FileName, voiceType)).ToList());
+            //                             }
+            //                         }
+            //                         else
+            //                         {
+            //                             var voiceTypes = resp.DialogGroup.TryResolve(linkCache)?.Conditions
+            //                                 .Where(condition => condition.Data is GetIsVoiceTypeConditionData)
+            //                                 .Select(condition => ((GetIsVoiceTypeConditionData)condition.Data).FirstParameter.Link.TryResolve(linkCache)?.EditorID).OfType<string>();
+            //                             var aliasVoiceTypes = resp.DialogGroup.TryResolve(linkCache)?.Conditions
+            //                                 .Where(condition => condition.Data is GetIsAliasRefConditionData)
+            //                                 .Where(condition =>
+            //                                     ((GetIsAliasRefConditionData)condition.Data).SecondParameter ==
+            //                                     1) // is true
+            //                                 .Select(cond =>
+            //                                 {
+            //                                     var aliasNum = ((GetIsAliasRefConditionData)cond.Data).FirstParameter;
+            //                                     if (quest.Aliases != null)
+            //                                     {
+            //                                         quest.Aliases.OfType<QuestReferenceAlias>()
+            //                                             .Where(alias => alias.)
+            //                                             .First(alias => alias.ID == aliasNum);
+            //                                     }
+            //                                 });
+            //                             voiceTypes?.ForEach(vt =>
+            //                             {
+            //                                 var wemPath = BuildWemPath(esm.FileName, vt, innerResp.WEMFile.ToString("x8"));
+            //                                 List<VoiceLine> voiceLines = [new VoiceLine(wemPath, innerRespText, esm.FileName, vt)];
+            //                                 tempDict.AddOrUpdate(vt, voiceLines, (_, lines) => lines.Append(new VoiceLine(wemPath, innerRespText, esm.FileName, vt)).ToList());
+            //                             });
+            //                         }
+            //                     }
+            //                     else
+            //                     {
+            //                         allVoiceTypesInQuest?.ForEach(voiceType =>
+            //                         {
+            //                             var wemPath = BuildWemPath(esm.FileName, voiceType,
+            //                                 innerResp.WEMFile.ToString("x8"));
+            //
+            //                             List<VoiceLine> voiceLineList =
+            //                                 [new VoiceLine(wemPath, innerRespText, esm.FileName, voiceType)];
+            //                             tempDict.AddOrUpdate(voiceType, voiceLineList,
+            //                                 (_, lines) =>
+            //                                     lines.Append(new VoiceLine(wemPath, innerRespText, esm.FileName,
+            //                                         voiceType)).ToList());
+            //                         });
+            //                     }
+            //                 });
+            //
+            //                 resp.Responses.Where(innerResp => innerResp.TROTs.Count > 0).ForEach(innerResp =>
+            //                 {
+            //                     innerResp.Text.TryLookup(Language.English, out var dialogueText);
+            //                     Log.Debug($"Parsing inner response {dialogueText}");
+            //                     // needs to support multiple unknown voice types
+            //                     var editorId = innerResp.TROTs
+            //                         .Select(trot => trot.UnknownVoiceType.TryResolve(linkCache)?.EditorID).OfType<string>();
+            //
+            //                     editorId.ForEach(voiceType =>
+            //                     {
+            //                         if (dialogueText != null)
+            //                         {
+            //                             var wemPath = BuildWemPath(esm.FileName, voiceType, innerResp.WEMFile.ToString("x8"));
+            //                             List<VoiceLine> voiceLineList = [new(wemPath, dialogueText, esm.FileName, voiceType)];
+            //                             tempDict.AddOrUpdate(voiceType, voiceLineList, (_, lines) => lines.Append(new VoiceLine(wemPath, dialogueText, esm.FileName, voiceType)).ToList());
+            //                         }
+            //                     });
+            //                 });
+            //
+            //             });
+            //         });
+            //
+            //         questCount++;
+            //     });
+            //
+            //     var voiceTypes = tempDict.Select(voiceType =>
+            //     {
+            //         var editorId = voiceType.Key;
+            //         var lines = voiceType.Value;
+            //         return new VoiceType()
+            //         {
+            //             EditorId = editorId,
+            //             VoiceLines = lines
+            //         };
+            //
+            //     }).OrderBy(voiceType => voiceType.EditorId).ToList();
+            //
+            //     if (voiceTypes.Count > 0)
+            //     {
+            //         return new Master(esm.FileName, voiceTypes);
+            //     }
+            //
+            //     return null;
+            // }).Where(master => master != null).ToList();
 
             SaveCache(tree);
+            Log.Information("Found {0} lines", lineCount);
 
             return tree;
         }
 
-        private IEnumerable<string>? GetQuestConditionalVoiceTypes(IQuestGetter quest, ILinkCache<IStarfieldMod, IStarfieldModGetter> linkCache)
+        private IEnumerable<string>? GetQuestConditionalVoiceTypes(IQuestGetter quest,
+            ILinkCache<IStarfieldMod, IStarfieldModGetter> linkCache)
         {
             if (quest.DialogConditions.Any())
             {
@@ -163,8 +258,9 @@ namespace StarfieldVT.Core
                 var getIsVoiceTypeConditionDatas = questConditions.ToList();
                 if (getIsVoiceTypeConditionDatas.Any())
                 {
-                    var voiceTypeConditionFormKey = getIsVoiceTypeConditionDatas.Select(condition => condition.FirstParameter)
-                    .First().Link.FormKey;
+                    var voiceTypeConditionFormKey = getIsVoiceTypeConditionDatas
+                        .Select(condition => condition.FirstParameter)
+                        .First().Link.FormKey;
                     var voiceTypeConditionFormListKey = voiceTypeConditionFormKey.ToLink<IFormListGetter>();
 
                     return voiceTypeConditionFormListKey.TryResolve(linkCache)?.Items
@@ -187,6 +283,35 @@ namespace StarfieldVT.Core
         {
             Log.Information("Saving generated tree to cache");
             _voiceLineTreeCacheManager.SaveCurrentTree(tree);
+        }
+
+        private void ProcessResponse(IDialogResponseGetter innerResp, IModListingGetter<IStarfieldModGetter> esm,
+            ConcurrentDictionary<string, List<VoiceLine>> tempDict, Dictionary<string, List<WemFileReference>> wemDict)
+        {
+            innerResp.Text.TryLookup(Language.English, out var innerRespText);
+            var wemFileName = innerResp.WEMFile.ToString("x8") + ".wem";
+            // remove the mod index from the filename and prefix with 00 so we can find it in the archive
+            var processedWemFile = "00" + wemFileName.Substring(2);
+
+            try
+            {
+                var wemFileRefs = wemDict[processedWemFile];
+                wemFileRefs.ForEach(wemFile =>
+                {
+                    lineCount++;
+                    //var voiceType = Path.GetFileName(Path.GetDirectoryName(wemFile.WemPath));
+                    List<VoiceLine> voiceLineList =
+                        [new VoiceLine(wemFile.WemPath, innerRespText, esm.FileName, wemFile.VoiceType)];
+                    tempDict.AddOrUpdate(wemFile.VoiceType, voiceLineList,
+                        (_, lines) =>
+                            lines.Append(new VoiceLine(wemFile.WemPath, innerRespText, esm.FileName, wemFile.VoiceType))
+                                .ToList());
+                });
+            }
+            catch (KeyNotFoundException ex)
+            {
+                Log.Warning("Could not find wem file {0} in archive, continuing on.", processedWemFile);
+            }
         }
     }
 }

--- a/StarfieldVT.Core/StarfieldVT.Core.csproj
+++ b/StarfieldVT.Core/StarfieldVT.Core.csproj
@@ -5,8 +5,8 @@
     <Nullable>enable</Nullable>
     <UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
-    <AssemblyVersion>0.2.0.0</AssemblyVersion>
-    <FileVersion>0.2.0.0</FileVersion>
+    <AssemblyVersion>0.3.0.0</AssemblyVersion>
+    <FileVersion>0.3.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/StarfieldVT.Core/VoiceArchiveManager.cs
+++ b/StarfieldVT.Core/VoiceArchiveManager.cs
@@ -1,0 +1,87 @@
+﻿using System.IO;
+using Mutagen.Bethesda;
+using Mutagen.Bethesda.Archives;
+using Mutagen.Bethesda.Installs;
+using Noggog;
+using Serilog;
+
+namespace StarfieldVT.Core;
+
+public class VoiceArchiveManager
+{
+    private DirectoryPath _dataFolder = GameLocations.GetDataFolder(GameRelease.Starfield);
+    public IEnumerable<FilePath> GetApplicableVoiceArchives(string modFileName)
+    {
+        var archivePrefix = modFileName.Replace(".esm", "").Replace(".esp", "");
+        return Archive.GetApplicableArchivePaths(GameRelease.Starfield, _dataFolder).Where(archive =>
+            archive.NameWithoutExtension.StartsWith("Starfield - Voices")
+            || archive.NameWithoutExtension.Contains(archivePrefix)
+            && archive.NameWithoutExtension.ToLower().Contains("voices")
+            && archive.NameWithoutExtension.ToLower().Contains("en"));
+    }
+    public List<IArchiveFile> FindVoiceFileByName(string name, string modFileName)
+    {
+        var archives = GetApplicableVoiceArchives(modFileName);
+        var voiceFiles = new List<IArchiveFile>();
+
+        foreach (var archive in archives)
+        {
+            var archiveReader = Archive.CreateReader(GameRelease.Starfield, archive);
+            var voiceFile = archiveReader.Files.FirstOrDefault(file => file.Path.EndsWith(name));
+
+            if (voiceFile is not null)
+            {
+                voiceFiles.Add(voiceFile);
+            }
+        }
+
+        return voiceFiles;
+    }
+
+    public Dictionary<string, List<WemFileReference>> BuildWemMap(string modFileName)
+    {
+        Log.Information("Building wem Map for {0}", modFileName);
+        var archives = GetApplicableVoiceArchives(modFileName);
+        var wemDict = new Dictionary<string, List<WemFileReference>>();
+
+        archives.ForEach(archive =>
+        {
+            Log.Debug("Reading archive file {0}", archive.Path);
+            var archiveReader = Archive.CreateReader(GameRelease.Starfield, archive);
+            archiveReader.Files.Where(file => file.Path.EndsWith(".wem")).ForEach(file =>
+            {
+                var wemFilename = Path.GetFileName(file.Path);
+                var wemFileReference = new WemFileReference(file.Path);
+
+                if (wemDict.ContainsKey(wemFilename))
+                {
+                    wemDict[wemFilename].Add(wemFileReference);
+                }
+                else
+                {
+                    wemDict.Add(wemFilename, [wemFileReference]);
+                }
+            });
+        });
+
+        return wemDict;
+    }
+}
+
+public class WemFileReference
+{
+    public string WemPath { get; set; }
+    public string VoiceType { get; }
+
+    public WemFileReference(string wemPath, string voiceType)
+    {
+        this.WemPath = wemPath;
+        this.VoiceType = voiceType;
+    }
+
+    public WemFileReference(string wemPath)
+    {
+        this.WemPath = wemPath;
+        this.VoiceType = Path.GetFileName(Path.GetDirectoryName(wemPath)) ?? throw new InvalidOperationException();
+    }
+}

--- a/StarfieldVT.UI/ViewModel/VoiceTypeTreeViewModel.cs
+++ b/StarfieldVT.UI/ViewModel/VoiceTypeTreeViewModel.cs
@@ -64,8 +64,15 @@ public class VoiceTypeTreeViewModel
             var treeCache = _cacheManager.TryToLoadCache();
             try
             {
-                var tree = treeCache != null ? treeCache : _dialogueTreeBuilder.BuildTree(Progress).ToList();
+                var tree = treeCache ?? _dialogueTreeBuilder.BuildTree(Progress).ToList();
                 _searchableMasters = tree;
+
+                ((IProgress<EsmLoadingProgress>)Progress).Report(new EsmLoadingProgress()
+                {
+                    esmName = "",
+                    num = -1
+                });
+
                 return new ObservableCollection<Master>(tree);
             }
             catch (Exception e)

--- a/StarfieldVT/MainWindow.xaml.cs
+++ b/StarfieldVT/MainWindow.xaml.cs
@@ -151,6 +151,12 @@ namespace StarfieldVT
 
         private void VoiceTypeTree_OnProgressChanged(object? sender, VoiceTypeTree.VoiceTypeTreeProgressChangedEventHandler e)
         {
+            if (e.Progress.num < 0)
+            {
+                TreeBuilderProgressBar.Visibility = Visibility.Collapsed;
+                ProgressText.Content = "Loaded";
+                return;
+            }
             TreeBuilderProgressBar.Value = e.Progress.num;
             ProgressText.Content = $"Parsing quest {e.Progress.esmName}";
 


### PR DESCRIPTION
- Redoes the voice line parsing by using the archives to find voice types instead, this is much more foolproof 
- Adds an elapsed time to the logs for loading the voices
- Fixes the progress indicator so it properly goes away

I am working on a way to get better casing on the Voice Types as I know they're easier to read when in the proper casing.

Fixes #6.